### PR TITLE
Spike: Support line breaks in markdown

### DIFF
--- a/libs/web/components/src/Markdown.tsx
+++ b/libs/web/components/src/Markdown.tsx
@@ -1,0 +1,17 @@
+import type { FC } from "react";
+
+import RemarkGfm from "remark-gfm";
+import RemarkBreaks from "remark-breaks";
+import ReactMarkdown from "react-markdown";
+
+interface MarkdownProps {
+	input: string;
+}
+
+export const Markdown: FC<MarkdownProps> = ({ input }) => (
+	<ReactMarkdown
+		remarkPlugins={[[RemarkGfm, { singleTilde: false }], RemarkBreaks]}
+	>
+		{input}
+	</ReactMarkdown>
+);

--- a/libs/web/components/src/ProposalDetailsDisplay.tsx
+++ b/libs/web/components/src/ProposalDetailsDisplay.tsx
@@ -1,8 +1,7 @@
 import type { FC } from "react";
 import type { ProposalDetails, ProposalInfo } from "@app-gov/node/types";
 
-import RemarkGfm from "remark-gfm";
-import ReactMarkdown from "react-markdown";
+import { Markdown } from "@app-gov/web/components";
 
 interface ProposalDetailsDisplayProps {
 	proposalDetails: ProposalDetails;
@@ -38,9 +37,7 @@ export const ProposalDetailsDisplay: FC<ProposalDetailsDisplayProps> = ({
 			</div>
 			<div className="border-hero my-6 w-full border-b-2" />
 			<div className="text-xl">
-				<ReactMarkdown remarkPlugins={[[RemarkGfm, { singleTilde: false }]]}>
-					{proposalDetails?.description}
-				</ReactMarkdown>
+				<Markdown input={proposalDetails?.description} />
 			</div>
 		</div>
 	);

--- a/libs/web/components/src/ProposalDetailsField.tsx
+++ b/libs/web/components/src/ProposalDetailsField.tsx
@@ -1,10 +1,8 @@
 import type { ChangeEventHandler, FC } from "react";
 
 import { useState } from "react";
-import RemarkGfm from "remark-gfm";
-import ReactMarkdown from "react-markdown";
 import { classNames, If } from "react-extras";
-import { Button, TextArea } from "@app-gov/web/components";
+import { Button, Markdown, TextArea } from "@app-gov/web/components";
 
 interface ProposalDetailsFieldProps {
 	proposalDetails: string;
@@ -58,9 +56,7 @@ export const ProposalDetailsField: FC<ProposalDetailsFieldProps> = ({
 			</If>
 			<If condition={showPreview}>
 				<div className="border-dark flex w-full border-[3px] bg-white px-4 py-2">
-					<ReactMarkdown remarkPlugins={[[RemarkGfm, { singleTilde: false }]]}>
-						{proposalDetails || "Nothing to preview"}
-					</ReactMarkdown>
+					<Markdown input={proposalDetails || "Nothing to preview"} />
 				</div>
 			</If>
 		</div>

--- a/libs/web/components/src/index.ts
+++ b/libs/web/components/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./Button";
 export * from "./Header";
 export * from "./Layout";
+export * from "./Markdown";
 export * from "./ProposalAdvanced";
 export * from "./Select";
 export * from "./TextField";

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-extras": "^3.0.0",
     "react-markdown": "^8.0.3",
     "regenerator-runtime": "0.13.7",
+    "remark-breaks": "^3.0.2",
     "remark-gfm": "^3.0.1",
     "store": "^2.0.12",
     "tslib": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1526,6 +1526,7 @@ __metadata:
     react-markdown: ^8.0.3
     react-test-renderer: 18.2.0
     regenerator-runtime: 0.13.7
+    remark-breaks: ^3.0.2
     remark-gfm: ^3.0.1
     store: ^2.0.12
     tailwindcss: ^3.1.2
@@ -13471,6 +13472,17 @@ __metadata:
   bin:
     regjsparser: bin/parser
   checksum: d069b932491761cda127ce11f6bd2729c3b1b394a35200ec33f1199e937423db28ceb86cf33f0a97c76ecd7c0f8db996476579eaf0d80a1f74c1934f4ca8b27a
+  languageName: node
+  linkType: hard
+
+"remark-breaks@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "remark-breaks@npm:3.0.2"
+  dependencies:
+    "@types/mdast": ^3.0.0
+    unified: ^10.0.0
+    unist-util-visit: ^4.0.0
+  checksum: 5f46b18818f8a77e4fbc607c99736eedbe1f8cbad3d7390ce8359f08e3b749de8778ec8812287a41f51ffef2524b0be0dd623fcdbcda5de7f13f9902851f80b3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

 - Support line breaks in markdown for `ProposalDetails` components

## Notes

 - Only supports single line breaks, not two in a row

<img width="726" alt="Screen Shot 2022-06-30 at 9 20 27 AM" src="https://user-images.githubusercontent.com/52016903/176546889-e6c52996-9689-4c8c-a30c-19a35394bd74.png">

