### PR TITLE
Chore: Lint and Format

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -17,5 +17,9 @@
         "tabWidth": 2
       }
     }
-  ]
+  ],
+  "importOrder": ["<THIRD_PARTY_MODULES>", "^@app-gov/(.*)$", "^[./]"],
+  "importOrderSeparation": true,
+  "importOrderSortSpecifiers": true,
+  "importOrderCaseInsensitive": true
 }

--- a/apps/gov-website/pages/_app.tsx
+++ b/apps/gov-website/pages/_app.tsx
@@ -1,16 +1,17 @@
 /* eslint-disable react/jsx-key */
+import { SessionProvider } from "next-auth/react";
 import type { AppProps } from "next/app";
 import Head from "next/head";
+import { FC } from "react";
+
 import { CENNZ_NETWORK } from "@app-gov/service/constants";
 import {
-	MainProvider,
 	CENNZApiProvider,
 	CENNZExtensionProvider,
 	CENNZWalletProvider,
+	MainProvider,
 	UserAgentProvider,
 } from "@app-gov/web/providers";
-import { FC } from "react";
-import { SessionProvider } from "next-auth/react";
 
 import "../globals.css";
 

--- a/apps/gov-website/pages/_document.tsx
+++ b/apps/gov-website/pages/_document.tsx
@@ -1,4 +1,4 @@
-import { Html, Head, Main, NextScript } from "next/document";
+import { Head, Html, Main, NextScript } from "next/document";
 import { FC } from "react";
 
 const NextDocument: FC = () => {

--- a/apps/gov-website/pages/api/auth/[...nextauth].ts
+++ b/apps/gov-website/pages/api/auth/[...nextauth].ts
@@ -1,6 +1,7 @@
 import NextAuth from "next-auth";
-import TwitterProvider from "next-auth/providers/twitter";
 import DiscordProvider from "next-auth/providers/discord";
+import TwitterProvider from "next-auth/providers/twitter";
+
 import { DISCORD_CLIENT, TWITTER_CLIENT } from "@app-gov/service/constants";
 
 export default NextAuth({

--- a/apps/gov-website/pages/api/identity/judgement.tsx
+++ b/apps/gov-website/pages/api/identity/judgement.tsx
@@ -1,14 +1,15 @@
+import { getToken } from "next-auth/jwt";
+
 import { NEXTAUTH_SECRET } from "@app-gov/node/constants";
 import { fetchRequiredRegistrars, withMethodGuard } from "@app-gov/node/utils";
 import {
 	fetchIdentityOf,
 	getApiInstance,
-	isIdentityValueMatched,
 	getProvideJudgementExtrinsic,
+	isIdentityValueMatched,
 	signAndSendPromise,
 } from "@app-gov/service/cennznet";
 import { CENNZ_NETWORK } from "@app-gov/service/constants";
-import { getToken } from "next-auth/jwt";
 
 export default withMethodGuard(
 	async function identityConnectRoute(req, res) {

--- a/apps/gov-website/pages/api/proposals/[pid].ts
+++ b/apps/gov-website/pages/api/proposals/[pid].ts
@@ -1,6 +1,6 @@
+import mongoose from "mongoose";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import mongoose from "mongoose";
 import { MONGODB_SERVER } from "@app-gov/service/constants";
 
 export default async function handler(

--- a/apps/gov-website/pages/identity/connect.tsx
+++ b/apps/gov-website/pages/identity/connect.tsx
@@ -1,27 +1,28 @@
 import type { GetStaticProps, NextPage } from "next";
 import { FormEvent, useCallback, useEffect } from "react";
-import {
-	DiscordLogo,
-	TwitterLogo,
-	Spinner,
-	X,
-	CheckCircle,
-	ExclamationCircle,
-} from "@app-gov/web/vectors";
-import { useSocialSignIn, useIdentityConnectForm } from "@app-gov/web/hooks";
 import { Choose, If } from "react-extras";
-import {
-	Button,
-	TextField,
-	WalletSelect,
-	Layout,
-	Header,
-	TransactionDialog,
-	useTransactionDialog,
-} from "@app-gov/web/components";
+
+import { fetchRequiredRegistrars } from "@app-gov/node/utils";
 import { getApiInstance } from "@app-gov/service/cennznet";
 import { CENNZ_NETWORK } from "@app-gov/service/constants";
-import { fetchRequiredRegistrars } from "@app-gov/node/utils";
+import {
+	Button,
+	Header,
+	Layout,
+	TextField,
+	TransactionDialog,
+	useTransactionDialog,
+	WalletSelect,
+} from "@app-gov/web/components";
+import { useIdentityConnectForm, useSocialSignIn } from "@app-gov/web/hooks";
+import {
+	CheckCircle,
+	DiscordLogo,
+	ExclamationCircle,
+	Spinner,
+	TwitterLogo,
+	X,
+} from "@app-gov/web/vectors";
 
 interface StaticProps {
 	twitterRegistrarIndex: number;

--- a/apps/gov-website/pages/index.tsx
+++ b/apps/gov-website/pages/index.tsx
@@ -1,4 +1,5 @@
 import type { NextPage } from "next";
+
 import { Header, Layout } from "@app-gov/web/components";
 
 const Home: NextPage = () => {

--- a/apps/gov-website/pages/popup/signin.tsx
+++ b/apps/gov-website/pages/popup/signin.tsx
@@ -1,10 +1,11 @@
+import { capitalize } from "lodash-es";
 import type { NextPage } from "next";
-import { Layout } from "@app-gov/web/components";
+import { BuiltInProviderType } from "next-auth/providers";
+import { signIn } from "next-auth/react";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
-import { signIn } from "next-auth/react";
-import { BuiltInProviderType } from "next-auth/providers";
-import { capitalize } from "lodash-es";
+
+import { Layout } from "@app-gov/web/components";
 
 const SignIn: NextPage = () => {
 	const {

--- a/apps/gov-website/pages/proposals/[pid].tsx
+++ b/apps/gov-website/pages/proposals/[pid].tsx
@@ -1,9 +1,9 @@
-import type { NextPage, NextPageContext } from "next";
 import type { SubmittableResult } from "@cennznet/api";
-import type { ProposalVote, ProposalInterface } from "@app-gov/node/types";
-
-import { If } from "react-extras";
+import type { NextPage, NextPageContext } from "next";
 import { useCallback, useEffect, useState } from "react";
+import { If } from "react-extras";
+
+import type { ProposalInterface, ProposalVote } from "@app-gov/node/types";
 import {
 	Button,
 	Header,
@@ -11,9 +11,9 @@ import {
 	ProposalDetailsDisplay,
 	WalletSelect,
 } from "@app-gov/web/components";
+import { useCENNZApi, useCENNZWallet } from "@app-gov/web/providers";
 import { fetchProposal } from "@app-gov/web/utils";
 import { Spinner } from "@app-gov/web/vectors";
-import { useCENNZApi, useCENNZWallet } from "@app-gov/web/providers";
 
 export const getServerSideProps = (context: NextPageContext) => {
 	return {

--- a/apps/gov-website/pages/proposals/new.tsx
+++ b/apps/gov-website/pages/proposals/new.tsx
@@ -1,7 +1,10 @@
-import type { NextPage } from "next";
-import type { ProposalCall } from "@app-gov/web/types";
 import type { Api, SubmittableResult } from "@cennznet/api";
+import type { NextPage } from "next";
+import { FormEventHandler, useCallback, useState } from "react";
+import { If } from "react-extras";
 
+import { PINATA_GATEWAY } from "@app-gov/service/constants";
+import { pinProposal } from "@app-gov/service/pinata";
 import {
 	Button,
 	Header,
@@ -11,13 +14,10 @@ import {
 	TextField,
 	WalletSelect,
 } from "@app-gov/web/components";
-import { If } from "react-extras";
-import { Spinner } from "@app-gov/web/vectors";
-import { pinProposal } from "@app-gov/service/pinata";
 import { useControlledInput } from "@app-gov/web/hooks";
-import { PINATA_GATEWAY } from "@app-gov/service/constants";
-import { FormEventHandler, useCallback, useState } from "react";
 import { useCENNZApi, useCENNZWallet } from "@app-gov/web/providers";
+import type { ProposalCall } from "@app-gov/web/types";
+import { Spinner } from "@app-gov/web/vectors";
 
 const NewProposal: NextPage = () => {
 	const { value: proposalTitle, onChange: onProposalTitleChange } =

--- a/apps/gov-website/specs/index.spec.tsx
+++ b/apps/gov-website/specs/index.spec.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import { render } from "@testing-library/react";
+import React from "react";
 
 import Index from "../pages/index";
 

--- a/libs/node/utils/src/fetchRequiredRegistrars.ts
+++ b/libs/node/utils/src/fetchRequiredRegistrars.ts
@@ -1,13 +1,14 @@
 import { Api } from "@cennznet/api";
-import {
-	fetchIdentityRegistrars,
-	getKeyringPairFromSeed,
-} from "@app-gov/service/cennznet";
+import { KeyringPair } from "@polkadot/keyring/types";
+
 import {
 	DISCORD_REGISTRAR_SEED,
 	TWITTER_REGISTRAR_SEED,
 } from "@app-gov/node/constants";
-import { KeyringPair } from "@polkadot/keyring/types";
+import {
+	fetchIdentityRegistrars,
+	getKeyringPairFromSeed,
+} from "@app-gov/service/cennznet";
 
 interface Registrar {
 	address: string;

--- a/libs/service/cennznet/src/Transaction.ts
+++ b/libs/service/cennznet/src/Transaction.ts
@@ -1,7 +1,8 @@
-import type { GenericEvent } from "@cennznet/types";
 import { SubmittableResult } from "@cennznet/api";
-import { CENNZ_NETWORK } from "@app-gov/service/constants";
+import type { GenericEvent } from "@cennznet/types";
 import Emittery from "emittery";
+
+import { CENNZ_NETWORK } from "@app-gov/service/constants";
 
 interface EmitEvents {
 	txCreated: undefined;

--- a/libs/service/cennznet/src/getSetIdentityExtrinsic.ts
+++ b/libs/service/cennznet/src/getSetIdentityExtrinsic.ts
@@ -1,6 +1,7 @@
 import { Api } from "@cennznet/api";
 import { SubmittableExtrinsic } from "@cennznet/api/types";
 import { ISubmittableResult } from "@cennznet/types";
+
 import { hasIdentityValue, IdentityHash } from "./hashIdentityValue";
 
 export function getSetIdentityExtrinsic(

--- a/libs/service/cennznet/src/signAndSendTx.ts
+++ b/libs/service/cennznet/src/signAndSendTx.ts
@@ -1,7 +1,8 @@
 import { SubmittableResult } from "@cennznet/api";
 import type { Signer, SubmittableExtrinsic } from "@cennznet/api/types";
-import { Transaction } from "./Transaction";
 import { KeyringPair } from "@polkadot/keyring/types";
+
+import { Transaction } from "./Transaction";
 
 export const signAndSendTx = async (
 	extrinsic: SubmittableExtrinsic<"promise">,

--- a/libs/service/constants/src/index.ts
+++ b/libs/service/constants/src/index.ts
@@ -1,5 +1,5 @@
-import { OAuthUserConfig } from "next-auth/providers";
 import { CENNZNetNetwork } from "@cennznet/api/types";
+import { OAuthUserConfig } from "next-auth/providers";
 
 export const CENNZ_NETWORK = {
 	local: {

--- a/libs/web/components/src/Button.tsx
+++ b/libs/web/components/src/Button.tsx
@@ -1,7 +1,7 @@
-import type { PropsWithChildren, IntrinsicElements } from "@app-gov/web/types";
-
 import { FC, ReactNode } from "react";
 import { classNames, If } from "react-extras";
+
+import type { IntrinsicElements, PropsWithChildren } from "@app-gov/web/types";
 
 interface ButtonProps extends PropsWithChildren {
 	variant?: "hero" | "white";

--- a/libs/web/components/src/Dialog.tsx
+++ b/libs/web/components/src/Dialog.tsx
@@ -1,7 +1,8 @@
-import { PropsWithChildren } from "@app-gov/web/types";
 import { Dialog as BaseDialog, Transition } from "@headlessui/react";
-import { FC, MutableRefObject, Fragment } from "react";
+import { FC, Fragment, MutableRefObject } from "react";
 import { classNames } from "react-extras";
+
+import { PropsWithChildren } from "@app-gov/web/types";
 
 export interface DialogProps extends PropsWithChildren {
 	className?: string;

--- a/libs/web/components/src/Header.tsx
+++ b/libs/web/components/src/Header.tsx
@@ -1,6 +1,6 @@
-import type { PropsWithChildren, IntrinsicElements } from "@app-gov/web/types";
-
 import { FC } from "react";
+
+import type { IntrinsicElements, PropsWithChildren } from "@app-gov/web/types";
 import { CENNZNetLogoSrc } from "@app-gov/web/vectors";
 
 interface HeaderProps extends PropsWithChildren {}

--- a/libs/web/components/src/Layout.tsx
+++ b/libs/web/components/src/Layout.tsx
@@ -1,6 +1,6 @@
-import type { PropsWithChildren, IntrinsicElements } from "@app-gov/web/types";
-
 import { FC } from "react";
+
+import type { IntrinsicElements, PropsWithChildren } from "@app-gov/web/types";
 
 interface LayoutProps extends PropsWithChildren {}
 

--- a/libs/web/components/src/Markdown.tsx
+++ b/libs/web/components/src/Markdown.tsx
@@ -1,8 +1,7 @@
 import type { FC } from "react";
-
-import RemarkGfm from "remark-gfm";
-import RemarkBreaks from "remark-breaks";
 import ReactMarkdown from "react-markdown";
+import RemarkBreaks from "remark-breaks";
+import RemarkGfm from "remark-gfm";
 
 interface MarkdownProps {
 	input: string;

--- a/libs/web/components/src/ProposalAdvanced.tsx
+++ b/libs/web/components/src/ProposalAdvanced.tsx
@@ -3,9 +3,10 @@ import { useMemo, useState } from "react";
 import { classNames, If } from "react-extras";
 
 import { Extrinsics } from "@app-gov/service/cennznet";
-import { Select, TextField } from "@app-gov/web/components";
 import type { ProposalCall } from "@app-gov/web/types";
 import { ChevronDown } from "@app-gov/web/vectors";
+
+import { Select, TextField } from "./";
 
 interface ProposalAdvancedProps {
 	proposalCall: ProposalCall | undefined;
@@ -128,7 +129,7 @@ const useExtrinsic = (proposalCall: ProposalCall | undefined) => {
 
 	const cennzCalls = useMemo(
 		() => selectedModule?.methods.map((method: ExtrinsicMethod) => method.name),
-		[selectedModule, proposalCall?.module]
+		[selectedModule]
 	);
 
 	const extrinsicArgs = useMemo<string[]>(() => {
@@ -141,7 +142,7 @@ const useExtrinsic = (proposalCall: ProposalCall | undefined) => {
 			.split(",")
 			.map((args: string) => args.split(":")[0])
 			.filter(Boolean);
-	}, [selectedModule, proposalCall]);
+	}, [proposalCall?.call, selectedModule?.methods]);
 
 	return { cennzModules, cennzCalls, extrinsicArgs };
 };

--- a/libs/web/components/src/ProposalAdvanced.tsx
+++ b/libs/web/components/src/ProposalAdvanced.tsx
@@ -1,11 +1,11 @@
 import type { ChangeEvent, FC } from "react";
-import type { ProposalCall } from "@app-gov/web/types";
-
 import { useMemo, useState } from "react";
 import { classNames, If } from "react-extras";
-import { ChevronDown } from "@app-gov/web/vectors";
+
 import { Extrinsics } from "@app-gov/service/cennznet";
-import { TextField, Select } from "@app-gov/web/components";
+import { Select, TextField } from "@app-gov/web/components";
+import type { ProposalCall } from "@app-gov/web/types";
+import { ChevronDown } from "@app-gov/web/vectors";
 
 interface ProposalAdvancedProps {
 	proposalCall: ProposalCall | undefined;

--- a/libs/web/components/src/ProposalDetailsDisplay.tsx
+++ b/libs/web/components/src/ProposalDetailsDisplay.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
-import type { ProposalDetails, ProposalInfo } from "@app-gov/node/types";
 
+import type { ProposalDetails, ProposalInfo } from "@app-gov/node/types";
 import { Markdown } from "@app-gov/web/components";
 
 interface ProposalDetailsDisplayProps {

--- a/libs/web/components/src/ProposalDetailsDisplay.tsx
+++ b/libs/web/components/src/ProposalDetailsDisplay.tsx
@@ -1,7 +1,8 @@
 import type { FC } from "react";
 
 import type { ProposalDetails, ProposalInfo } from "@app-gov/node/types";
-import { Markdown } from "@app-gov/web/components";
+
+import { Markdown } from "./";
 
 interface ProposalDetailsDisplayProps {
 	proposalDetails: ProposalDetails;

--- a/libs/web/components/src/ProposalDetailsField.tsx
+++ b/libs/web/components/src/ProposalDetailsField.tsx
@@ -1,9 +1,9 @@
 import type { ChangeEventHandler, FC } from "react";
-
 import { useState } from "react";
 import { classNames, If } from "react-extras";
-import { useControlledInput } from "@app-gov/web/hooks";
+
 import { Button, Markdown, TextArea } from "@app-gov/web/components";
+import { useControlledInput } from "@app-gov/web/hooks";
 
 export const ProposalDetailsField: FC = () => {
 	const [showPreview, setShowPreview] = useState<boolean>(false);

--- a/libs/web/components/src/ProposalDetailsField.tsx
+++ b/libs/web/components/src/ProposalDetailsField.tsx
@@ -1,9 +1,10 @@
-import type { ChangeEventHandler, FC } from "react";
+import type { FC } from "react";
 import { useState } from "react";
 import { classNames, If } from "react-extras";
 
-import { Button, Markdown, TextArea } from "@app-gov/web/components";
 import { useControlledInput } from "@app-gov/web/hooks";
+
+import { Button, Markdown, TextArea } from "./";
 
 export const ProposalDetailsField: FC = () => {
 	const [showPreview, setShowPreview] = useState<boolean>(false);

--- a/libs/web/components/src/Select.tsx
+++ b/libs/web/components/src/Select.tsx
@@ -1,7 +1,7 @@
-import type { PropsWithChildren, IntrinsicElements } from "@app-gov/web/types";
-
 import { FC, ReactNode } from "react";
 import { classNames, If } from "react-extras";
+
+import type { IntrinsicElements, PropsWithChildren } from "@app-gov/web/types";
 
 interface SelectProps extends PropsWithChildren {
 	placeholder?: string;

--- a/libs/web/components/src/TextField.tsx
+++ b/libs/web/components/src/TextField.tsx
@@ -1,7 +1,7 @@
-import type { PropsWithChildren, IntrinsicElements } from "@app-gov/web/types";
-
 import { FC, ReactNode } from "react";
 import { classNames, If } from "react-extras";
+
+import type { IntrinsicElements, PropsWithChildren } from "@app-gov/web/types";
 
 interface TextFieldProps extends PropsWithChildren {
 	endAdornment?: ReactNode;

--- a/libs/web/components/src/TransactionDialog.tsx
+++ b/libs/web/components/src/TransactionDialog.tsx
@@ -1,5 +1,6 @@
+import { ComponentProps, FC, useCallback, useRef, useState } from "react";
+
 import { Dialog } from "@app-gov/web/components";
-import { ComponentProps, FC, useRef, useState, useCallback } from "react";
 
 interface TransactionDialogProps extends ComponentProps<typeof Dialog> {}
 

--- a/libs/web/components/src/TransactionDialog.tsx
+++ b/libs/web/components/src/TransactionDialog.tsx
@@ -1,6 +1,6 @@
 import { ComponentProps, FC, useCallback, useRef, useState } from "react";
 
-import { Dialog } from "@app-gov/web/components";
+import { Dialog } from "./";
 
 interface TransactionDialogProps extends ComponentProps<typeof Dialog> {}
 

--- a/libs/web/components/src/WalletSelect.tsx
+++ b/libs/web/components/src/WalletSelect.tsx
@@ -1,8 +1,9 @@
 import type { ChangeEventHandler, MouseEventHandler } from "react";
 
-import { Button, Select } from "@app-gov/web/components";
 import { useCENNZExtension, useCENNZWallet } from "@app-gov/web/providers";
 import { CENNZLogo } from "@app-gov/web/vectors";
+
+import { Button, Select } from "./";
 
 export const WalletSelect: typeof Select = (props) => {
 	const {

--- a/libs/web/components/src/WalletSelect.tsx
+++ b/libs/web/components/src/WalletSelect.tsx
@@ -1,7 +1,7 @@
 import type { ChangeEventHandler, MouseEventHandler } from "react";
 
 import { Button, Select } from "@app-gov/web/components";
-import { useCENNZWallet, useCENNZExtension } from "@app-gov/web/providers";
+import { useCENNZExtension, useCENNZWallet } from "@app-gov/web/providers";
 import { CENNZLogo } from "@app-gov/web/vectors";
 
 export const WalletSelect: typeof Select = (props) => {

--- a/libs/web/hooks/src/useIdentityConnectForm.ts
+++ b/libs/web/hooks/src/useIdentityConnectForm.ts
@@ -1,10 +1,11 @@
 import { useCallback, useState } from "react";
-import { useCENNZApi, useCENNZWallet } from "@app-gov/web/providers";
+
 import {
 	getRequestJudgementExtrinsic,
 	getSetIdentityExtrinsic,
 	signAndSendTx,
 } from "@app-gov/service/cennznet";
+import { useCENNZApi, useCENNZWallet } from "@app-gov/web/providers";
 
 export interface IdentityFormState {
 	step: "Await" | "Submit" | "Process";

--- a/libs/web/hooks/src/useSocialSignIn.ts
+++ b/libs/web/hooks/src/useSocialSignIn.ts
@@ -1,5 +1,6 @@
-import { MouseEventHandler, useCallback, useState } from "react";
 import { getSession } from "next-auth/react";
+import { MouseEventHandler, useCallback, useState } from "react";
+
 import { useWindowPopup } from "./useWindowPopup";
 
 export const useSocialSignIn = (provider: "Twitter" | "Discord") => {

--- a/libs/web/providers/src/CENNZApiProvider.tsx
+++ b/libs/web/providers/src/CENNZApiProvider.tsx
@@ -1,8 +1,8 @@
-import type { PropsWithChildren } from "@app-gov/web/types";
-
-import { FC, createContext, useState, useEffect, useContext } from "react";
 import { Api } from "@cennznet/api";
 import { CENNZNetNetwork } from "@cennznet/api/types";
+import { createContext, FC, useContext, useEffect, useState } from "react";
+
+import type { PropsWithChildren } from "@app-gov/web/types";
 
 interface CENNZApiContextType {
 	api?: Api;

--- a/libs/web/providers/src/CENNZExtensionProvider.tsx
+++ b/libs/web/providers/src/CENNZExtensionProvider.tsx
@@ -1,19 +1,20 @@
-import type { PropsWithChildren } from "@app-gov/web/types";
-
+import type * as Extension from "@polkadot/extension-dapp";
 import {
-	InjectedExtension,
 	InjectedAccountWithMeta,
+	InjectedExtension,
 } from "@polkadot/extension-inject/types";
 import {
 	createContext,
+	FC,
+	useCallback,
 	useContext,
 	useEffect,
-	useState,
-	useCallback,
 	useMemo,
-	FC,
+	useState,
 } from "react";
-import type * as Extension from "@polkadot/extension-dapp";
+
+import type { PropsWithChildren } from "@app-gov/web/types";
+
 import { useUserAgent } from "./UserAgentProvider";
 
 interface CENNZExtensionContextType {

--- a/libs/web/providers/src/CENNZWalletProvider.tsx
+++ b/libs/web/providers/src/CENNZWalletProvider.tsx
@@ -1,19 +1,21 @@
-import type { PropsWithChildren } from "@app-gov/web/types";
 import {
-	InjectedExtension,
 	InjectedAccountWithMeta,
+	InjectedExtension,
 } from "@polkadot/extension-inject/types";
 import {
 	createContext,
+	FC,
 	useCallback,
 	useContext,
 	useEffect,
 	useState,
-	FC,
 } from "react";
 import store from "store";
-import { useCENNZExtension } from "./CENNZExtensionProvider";
+
+import type { PropsWithChildren } from "@app-gov/web/types";
+
 import { useCENNZApi } from "./CENNZApiProvider";
+import { useCENNZExtension } from "./CENNZExtensionProvider";
 
 interface CENNZWalletContextType {
 	selectedAccount?: InjectedAccountWithMeta;

--- a/libs/web/providers/src/MainProvider.tsx
+++ b/libs/web/providers/src/MainProvider.tsx
@@ -1,5 +1,6 @@
-import { PropsWithChildren } from "@app-gov/web/types";
 import { cloneElement, FC, ReactElement, ReactNode } from "react";
+
+import { PropsWithChildren } from "@app-gov/web/types";
 
 export interface MainProviderProps extends PropsWithChildren {
 	providers: ReactElement[];

--- a/libs/web/providers/src/UserAgentProvider.tsx
+++ b/libs/web/providers/src/UserAgentProvider.tsx
@@ -1,5 +1,6 @@
 import { createContext, FC, useContext, useEffect, useState } from "react";
-import type { IBrowser, IOS, IDevice } from "ua-parser-js";
+import type { IBrowser, IDevice, IOS } from "ua-parser-js";
+
 import { PropsWithChildren } from "@app-gov/web/types";
 
 type UserAgentContextType = {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@nrwl/web": "14.3.6",
     "@nrwl/workspace": "14.3.6",
     "@testing-library/react": "13.3.0",
+    "@trivago/prettier-plugin-sort-imports": "^3.2.0",
     "@types/jest": "27.4.1",
     "@types/lodash-es": "^4",
     "@types/node": "16.11.7",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
   },
   "packageManager": "yarn@3.2.1",
   "resolutions": {
-    "eslint": "^7",
     "@polkadot/util": "8.7.1",
     "@polkadot/util-crypto": "8.7.1",
     "lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,15 +15,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:7.12.11":
-  version: 7.12.11
-  resolution: "@babel/code-frame@npm:7.12.11"
-  dependencies:
-    "@babel/highlight": ^7.10.4
-  checksum: 3963eff3ebfb0e091c7e6f99596ef4b258683e4ba8a134e4e95f77afe85be5c931e184fff6435fb4885d12eba04a5e25532f7fbc292ca13b48e7da943474e2f3
-  languageName: node
-  linkType: hard
-
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.18.6, @babel/code-frame@npm:^7.8.3":
   version: 7.18.6
   resolution: "@babel/code-frame@npm:7.18.6"
@@ -376,7 +367,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/highlight@npm:^7.10.4, @babel/highlight@npm:^7.18.6":
+"@babel/highlight@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/highlight@npm:7.18.6"
   dependencies:
@@ -1739,20 +1730,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/eslintrc@npm:^0.4.3":
-  version: 0.4.3
-  resolution: "@eslint/eslintrc@npm:0.4.3"
+"@eslint/eslintrc@npm:^1.2.3":
+  version: 1.3.0
+  resolution: "@eslint/eslintrc@npm:1.3.0"
   dependencies:
     ajv: ^6.12.4
-    debug: ^4.1.1
-    espree: ^7.3.0
-    globals: ^13.9.0
-    ignore: ^4.0.6
+    debug: ^4.3.2
+    espree: ^9.3.2
+    globals: ^13.15.0
+    ignore: ^5.2.0
     import-fresh: ^3.2.1
-    js-yaml: ^3.13.1
-    minimatch: ^3.0.4
+    js-yaml: ^4.1.0
+    minimatch: ^3.1.2
     strip-json-comments: ^3.1.1
-  checksum: 03a7704150b868c318aab6a94d87a33d30dc2ec579d27374575014f06237ba1370ae11178db772f985ef680d469dc237e7b16a1c5d8edaaeb8c3733e7a95a6d3
+  checksum: a1e734ad31a8b5328dce9f479f185fd4fc83dd7f06c538e1fa457fd8226b89602a55cc6458cd52b29573b01cdfaf42331be8cfc1fec732570086b591f4ed6515
   languageName: node
   linkType: hard
 
@@ -2174,18 +2165,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@humanwhocodes/config-array@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "@humanwhocodes/config-array@npm:0.5.0"
+"@humanwhocodes/config-array@npm:^0.9.2":
+  version: 0.9.5
+  resolution: "@humanwhocodes/config-array@npm:0.9.5"
   dependencies:
-    "@humanwhocodes/object-schema": ^1.2.0
+    "@humanwhocodes/object-schema": ^1.2.1
     debug: ^4.1.1
     minimatch: ^3.0.4
-  checksum: 44ee6a9f05d93dd9d5935a006b17572328ba9caff8002442f601736cbda79c580cc0f5a49ce9eb88fbacc5c3a6b62098357c2e95326cd17bb9f1a6c61d6e95e7
+  checksum: 8ba6281bc0590f6c6eadeefc14244b5a3e3f5903445aadd1a32099ed80e753037674026ce1b3c945ab93561bea5eb29e3c5bff67060e230c295595ba517a3492
   languageName: node
   linkType: hard
 
-"@humanwhocodes/object-schema@npm:^1.2.0":
+"@humanwhocodes/object-schema@npm:^1.2.1":
   version: 1.2.1
   resolution: "@humanwhocodes/object-schema@npm:1.2.1"
   checksum: a824a1ec31591231e4bad5787641f59e9633827d0a2eaae131a288d33c9ef0290bd16fda8da6f7c0fcb014147865d12118df10db57f27f41e20da92369fcb3f1
@@ -4919,7 +4910,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-jsx@npm:^5.3.1":
+"acorn-jsx@npm:^5.3.2":
   version: 5.3.2
   resolution: "acorn-jsx@npm:5.3.2"
   peerDependencies:
@@ -4953,7 +4944,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^7.0.0, acorn@npm:^7.1.1, acorn@npm:^7.4.0":
+"acorn@npm:^7.0.0, acorn@npm:^7.1.1":
   version: 7.4.1
   resolution: "acorn@npm:7.4.1"
   bin:
@@ -4962,7 +4953,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.2.4, acorn@npm:^8.4.1, acorn@npm:^8.5.0":
+"acorn@npm:^8.2.4, acorn@npm:^8.4.1, acorn@npm:^8.5.0, acorn@npm:^8.7.1":
   version: 8.7.1
   resolution: "acorn@npm:8.7.1"
   bin:
@@ -5054,7 +5045,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^8.0.0, ajv@npm:^8.0.1, ajv@npm:^8.8.0":
+"ajv@npm:^8.0.0, ajv@npm:^8.8.0":
   version: 8.11.0
   resolution: "ajv@npm:8.11.0"
   dependencies:
@@ -5201,6 +5192,13 @@ __metadata:
   dependencies:
     sprintf-js: ~1.0.2
   checksum: 7ca6e45583a28de7258e39e13d81e925cfa25d7d4aacbf806a382d3c02fcb13403a07fb8aeef949f10a7cfe4a62da0e2e807b348a5980554cc28ee573ef95945
+  languageName: node
+  linkType: hard
+
+"argparse@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "argparse@npm:2.0.1"
+  checksum: 83644b56493e89a254bae05702abf3a1101b4fa4d0ca31df1c9985275a5a5bd47b3c27b7fa0b71098d41114d8ca000e6ed90cad764b306f8a503665e4d517ced
   languageName: node
   linkType: hard
 
@@ -6818,7 +6816,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:4.x, debug@npm:^4.0.0, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4":
+"debug@npm:4, debug@npm:4.x, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4":
   version: 4.3.4
   resolution: "debug@npm:4.3.4"
   dependencies:
@@ -7276,7 +7274,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enquirer@npm:^2.3.5, enquirer@npm:^2.3.6, enquirer@npm:~2.3.6":
+"enquirer@npm:^2.3.6, enquirer@npm:~2.3.6":
   version: 2.3.6
   resolution: "enquirer@npm:2.3.6"
   dependencies:
@@ -7710,12 +7708,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-utils@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "eslint-utils@npm:2.1.0"
+"eslint-scope@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "eslint-scope@npm:7.1.1"
   dependencies:
-    eslint-visitor-keys: ^1.1.0
-  checksum: 27500938f348da42100d9e6ad03ae29b3de19ba757ae1a7f4a087bdcf83ac60949bbb54286492ca61fac1f5f3ac8692dd21537ce6214240bf95ad0122f24d71d
+    esrecurse: ^4.3.0
+    estraverse: ^5.2.0
+  checksum: 9f6e974ab2db641ca8ab13508c405b7b859e72afe9f254e8131ff154d2f40c99ad4545ce326fd9fde3212ff29707102562a4834f1c48617b35d98c71a97fbf3e
   languageName: node
   linkType: hard
 
@@ -7727,13 +7726,6 @@ __metadata:
   peerDependencies:
     eslint: ">=5"
   checksum: 0668fe02f5adab2e5a367eee5089f4c39033af20499df88fe4e6aba2015c20720404d8c3d6349b6f716b08fdf91b9da4e5d5481f265049278099c4c836ccb619
-  languageName: node
-  linkType: hard
-
-"eslint-visitor-keys@npm:^1.1.0, eslint-visitor-keys@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "eslint-visitor-keys@npm:1.3.0"
-  checksum: 37a19b712f42f4c9027e8ba98c2b06031c17e0c0a4c696cd429bd9ee04eb43889c446f2cd545e1ff51bef9593fcec94ecd2c2ef89129fcbbf3adadbef520376a
   languageName: node
   linkType: hard
 
@@ -7751,64 +7743,59 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^7":
-  version: 7.32.0
-  resolution: "eslint@npm:7.32.0"
+"eslint@npm:~8.15.0":
+  version: 8.15.0
+  resolution: "eslint@npm:8.15.0"
   dependencies:
-    "@babel/code-frame": 7.12.11
-    "@eslint/eslintrc": ^0.4.3
-    "@humanwhocodes/config-array": ^0.5.0
+    "@eslint/eslintrc": ^1.2.3
+    "@humanwhocodes/config-array": ^0.9.2
     ajv: ^6.10.0
     chalk: ^4.0.0
     cross-spawn: ^7.0.2
-    debug: ^4.0.1
+    debug: ^4.3.2
     doctrine: ^3.0.0
-    enquirer: ^2.3.5
     escape-string-regexp: ^4.0.0
-    eslint-scope: ^5.1.1
-    eslint-utils: ^2.1.0
-    eslint-visitor-keys: ^2.0.0
-    espree: ^7.3.1
+    eslint-scope: ^7.1.1
+    eslint-utils: ^3.0.0
+    eslint-visitor-keys: ^3.3.0
+    espree: ^9.3.2
     esquery: ^1.4.0
     esutils: ^2.0.2
     fast-deep-equal: ^3.1.3
     file-entry-cache: ^6.0.1
     functional-red-black-tree: ^1.0.1
-    glob-parent: ^5.1.2
+    glob-parent: ^6.0.1
     globals: ^13.6.0
-    ignore: ^4.0.6
+    ignore: ^5.2.0
     import-fresh: ^3.0.0
     imurmurhash: ^0.1.4
     is-glob: ^4.0.0
-    js-yaml: ^3.13.1
+    js-yaml: ^4.1.0
     json-stable-stringify-without-jsonify: ^1.0.1
     levn: ^0.4.1
     lodash.merge: ^4.6.2
-    minimatch: ^3.0.4
+    minimatch: ^3.1.2
     natural-compare: ^1.4.0
     optionator: ^0.9.1
-    progress: ^2.0.0
-    regexpp: ^3.1.0
-    semver: ^7.2.1
-    strip-ansi: ^6.0.0
+    regexpp: ^3.2.0
+    strip-ansi: ^6.0.1
     strip-json-comments: ^3.1.0
-    table: ^6.0.9
     text-table: ^0.2.0
     v8-compile-cache: ^2.0.3
   bin:
     eslint: bin/eslint.js
-  checksum: cc85af9985a3a11085c011f3d27abe8111006d34cc274291b3c4d7bea51a4e2ff6135780249becd919ba7f6d6d1ecc38a6b73dacb6a7be08d38453b344dc8d37
+  checksum: d8896393832e154e1381a21041cfe4d12a73a76fac26ea27cabbc0e5fdac87918ad651f07f804ef6faacd3868572de3c1ec5d96edf5502bc999eff0c423638f7
   languageName: node
   linkType: hard
 
-"espree@npm:^7.3.0, espree@npm:^7.3.1":
-  version: 7.3.1
-  resolution: "espree@npm:7.3.1"
+"espree@npm:^9.3.2":
+  version: 9.3.2
+  resolution: "espree@npm:9.3.2"
   dependencies:
-    acorn: ^7.4.0
-    acorn-jsx: ^5.3.1
-    eslint-visitor-keys: ^1.3.0
-  checksum: aa9b50dcce883449af2e23bc2b8d9abb77118f96f4cb313935d6b220f77137eaef7724a83c3f6243b96bc0e4ab14766198e60818caad99f9519ae5a336a39b45
+    acorn: ^8.7.1
+    acorn-jsx: ^5.3.2
+    eslint-visitor-keys: ^3.3.0
+  checksum: 9a790d6779847051e87f70d720a0f6981899a722419e80c92ab6dee01e1ab83b8ce52d11b4dc96c2c490182efb5a4c138b8b0d569205bfe1cd4629e658e58c30
   languageName: node
   linkType: hard
 
@@ -8718,7 +8705,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globals@npm:^13.6.0, globals@npm:^13.9.0":
+"globals@npm:^13.15.0, globals@npm:^13.6.0":
   version: 13.15.0
   resolution: "globals@npm:13.15.0"
   dependencies:
@@ -9132,13 +9119,6 @@ __metadata:
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
   checksum: 5144c0c9815e54ada181d80a0b810221a253562422e7c6c3a60b1901154184f49326ec239d618c416c1c5945a2e197107aee8d986a3dd836b53dffefd99b5e7e
-  languageName: node
-  linkType: hard
-
-"ignore@npm:^4.0.6":
-  version: 4.0.6
-  resolution: "ignore@npm:4.0.6"
-  checksum: 248f82e50a430906f9ee7f35e1158e3ec4c3971451dd9f99c9bc1548261b4db2b99709f60ac6c6cac9333494384176cc4cc9b07acbe42d52ac6a09cad734d800
   languageName: node
   linkType: hard
 
@@ -10237,6 +10217,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-yaml@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "js-yaml@npm:4.1.0"
+  dependencies:
+    argparse: ^2.0.1
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: c7830dfd456c3ef2c6e355cc5a92e6700ceafa1d14bba54497b34a99f0376cecbb3e9ac14d3e5849b426d5a5140709a66237a8c991c675431271c4ce5504151a
+  languageName: node
+  linkType: hard
+
 "jsbn@npm:~0.1.0":
   version: 0.1.1
   resolution: "jsbn@npm:0.1.1"
@@ -10700,13 +10691,6 @@ __metadata:
   version: 4.1.1
   resolution: "lodash.once@npm:4.1.1"
   checksum: d768fa9f9b4e1dc6453be99b753906f58990e0c45e7b2ca5a3b40a33111e5d17f6edf2f768786e2716af90a8e78f8f91431ab8435f761fef00f9b0c256f6d245
-  languageName: node
-  linkType: hard
-
-"lodash.truncate@npm:^4.4.2":
-  version: 4.4.2
-  resolution: "lodash.truncate@npm:4.4.2"
-  checksum: b463d8a382cfb5f0e71c504dcb6f807a7bd379ff1ea216669aa42c52fc28c54e404bfbd96791aa09e6df0de2c1d7b8f1b7f4b1a61f324d38fe98bc535aeee4f5
   languageName: node
   linkType: hard
 
@@ -13188,13 +13172,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"progress@npm:^2.0.0":
-  version: 2.0.3
-  resolution: "progress@npm:2.0.3"
-  checksum: f67403fe7b34912148d9252cb7481266a354bd99ce82c835f79070643bb3c6583d10dbcfda4d41e04bbc1d8437e9af0fb1e1f2135727878f5308682a579429b7
-  languageName: node
-  linkType: hard
-
 "promise-inflight@npm:^1.0.1":
   version: 1.0.1
   resolution: "promise-inflight@npm:1.0.1"
@@ -13588,7 +13565,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regexpp@npm:^3.1.0, regexpp@npm:^3.2.0":
+"regexpp@npm:^3.2.0":
   version: 3.2.0
   resolution: "regexpp@npm:3.2.0"
   checksum: a78dc5c7158ad9ddcfe01aa9144f46e192ddbfa7b263895a70a5c6c73edd9ce85faf7c0430e59ac38839e1734e275b9c3de5c57ee3ab6edc0e0b1bdebefccef8
@@ -14150,7 +14127,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.x, semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7":
+"semver@npm:7.x, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7":
   version: 7.3.7
   resolution: "semver@npm:7.3.7"
   dependencies:
@@ -14887,19 +14864,6 @@ __metadata:
   version: 3.2.4
   resolution: "symbol-tree@npm:3.2.4"
   checksum: 6e8fc7e1486b8b54bea91199d9535bb72f10842e40c79e882fc94fb7b14b89866adf2fd79efa5ebb5b658bc07fb459ccce5ac0e99ef3d72f474e74aaf284029d
-  languageName: node
-  linkType: hard
-
-"table@npm:^6.0.9":
-  version: 6.8.0
-  resolution: "table@npm:6.8.0"
-  dependencies:
-    ajv: ^8.0.1
-    lodash.truncate: ^4.4.2
-    slice-ansi: ^4.0.0
-    string-width: ^4.2.3
-    strip-ansi: ^6.0.1
-  checksum: 5b07fe462ee03d2e1fac02cbb578efd2e0b55ac07e3d3db2e950aa9570ade5a4a2b8d3c15e9f25c89e4e50b646bc4269934601ee1eef4ca7968ad31960977690
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,6 +40,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/core@npm:7.13.10":
+  version: 7.13.10
+  resolution: "@babel/core@npm:7.13.10"
+  dependencies:
+    "@babel/code-frame": ^7.12.13
+    "@babel/generator": ^7.13.9
+    "@babel/helper-compilation-targets": ^7.13.10
+    "@babel/helper-module-transforms": ^7.13.0
+    "@babel/helpers": ^7.13.10
+    "@babel/parser": ^7.13.10
+    "@babel/template": ^7.12.13
+    "@babel/traverse": ^7.13.0
+    "@babel/types": ^7.13.0
+    convert-source-map: ^1.7.0
+    debug: ^4.1.0
+    gensync: ^1.0.0-beta.2
+    json5: ^2.1.2
+    lodash: ^4.17.19
+    semver: ^6.3.0
+    source-map: ^0.5.0
+  checksum: 9b3362fd02e6a4f3ad642893312ec3d22713c4eeb2571c994d49c31f38d24893a6a18f4b49abb8d56b510e116278608eaddde2ca72ccb39ab29350efa5af39de
+  languageName: node
+  linkType: hard
+
 "@babel/core@npm:^7.0.1, @babel/core@npm:^7.1.0, @babel/core@npm:^7.12.3, @babel/core@npm:^7.15.0, @babel/core@npm:^7.15.5, @babel/core@npm:^7.7.2, @babel/core@npm:^7.8.0":
   version: 7.18.6
   resolution: "@babel/core@npm:7.18.6"
@@ -60,6 +84,28 @@ __metadata:
     json5: ^2.2.1
     semver: ^6.3.0
   checksum: 711459ebf7afab7b8eff88b7155c3f4a62690545f1c8c2eb6ba5ebaed01abeecb984cf9657847a2151ad24a5645efce765832aa343ce0f0386f311b67b59589a
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:7.13.9":
+  version: 7.13.9
+  resolution: "@babel/generator@npm:7.13.9"
+  dependencies:
+    "@babel/types": ^7.13.0
+    jsesc: ^2.5.1
+    source-map: ^0.5.0
+  checksum: 1b0e9fa1b5ea6656f0abeeedc99ff7bffa455d7bf118f4d17a75d80c439206b4ba3e1071c104b486b7447689512969286cbde505e6169ab38cf437e13ca54225
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:^7.13.0, @babel/generator@npm:^7.13.9":
+  version: 7.18.7
+  resolution: "@babel/generator@npm:7.18.7"
+  dependencies:
+    "@babel/types": ^7.18.7
+    "@jridgewell/gen-mapping": ^0.3.2
+    jsesc: ^2.5.1
+  checksum: aad4b6873130165e9483af2888bce5a3a5ad9cca0757fc90ae11a0396757d0b295a3bff49282c8df8ab01b31972cc855ae88fd9ddc9ab00d9427dc0e01caeea9
   languageName: node
   linkType: hard
 
@@ -93,7 +139,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-compilation-targets@npm:^7.13.0, @babel/helper-compilation-targets@npm:^7.18.6":
+"@babel/helper-compilation-targets@npm:^7.13.0, @babel/helper-compilation-targets@npm:^7.13.10, @babel/helper-compilation-targets@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/helper-compilation-targets@npm:7.18.6"
   dependencies:
@@ -170,7 +216,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-function-name@npm:^7.18.6":
+"@babel/helper-function-name@npm:^7.12.13, @babel/helper-function-name@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/helper-function-name@npm:7.18.6"
   dependencies:
@@ -207,7 +253,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-transforms@npm:^7.18.6":
+"@babel/helper-module-transforms@npm:^7.13.0, @babel/helper-module-transforms@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/helper-module-transforms@npm:7.18.6"
   dependencies:
@@ -284,7 +330,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-split-export-declaration@npm:^7.18.6":
+"@babel/helper-split-export-declaration@npm:^7.12.13, @babel/helper-split-export-declaration@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/helper-split-export-declaration@npm:7.18.6"
   dependencies:
@@ -293,7 +339,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-identifier@npm:^7.18.6":
+"@babel/helper-validator-identifier@npm:^7.12.11, @babel/helper-validator-identifier@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/helper-validator-identifier@npm:7.18.6"
   checksum: e295254d616bbe26e48c196a198476ab4d42a73b90478c9842536cf910ead887f5af6b5c4df544d3052a25ccb3614866fa808dc1e3a5a4291acd444e243c0648
@@ -319,7 +365,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helpers@npm:^7.18.6":
+"@babel/helpers@npm:^7.13.10, @babel/helpers@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/helpers@npm:7.18.6"
   dependencies:
@@ -341,7 +387,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.18.6":
+"@babel/parser@npm:7.14.6":
+  version: 7.14.6
+  resolution: "@babel/parser@npm:7.14.6"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 104482e07971a78a3d68a0c329b1303981a272f55a510d39c93dac3c293f207ec863329046abc5d8bb86db58c49670cc607654793470a87ccd386544c2ccf298
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.13.0, @babel/parser@npm:^7.13.10, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/parser@npm:7.18.6"
   bin:
@@ -1415,7 +1470,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/template@npm:^7.18.6, @babel/template@npm:^7.3.3":
+"@babel/template@npm:^7.12.13, @babel/template@npm:^7.18.6, @babel/template@npm:^7.3.3":
   version: 7.18.6
   resolution: "@babel/template@npm:7.18.6"
   dependencies:
@@ -1423,6 +1478,23 @@ __metadata:
     "@babel/parser": ^7.18.6
     "@babel/types": ^7.18.6
   checksum: cb02ed804b7b1938dbecef4e01562013b80681843dd391933315b3dd9880820def3b5b1bff6320d6e4c6a1d63d1d5799630d658ec6b0369c5505e7e4029c38fb
+  languageName: node
+  linkType: hard
+
+"@babel/traverse@npm:7.13.0":
+  version: 7.13.0
+  resolution: "@babel/traverse@npm:7.13.0"
+  dependencies:
+    "@babel/code-frame": ^7.12.13
+    "@babel/generator": ^7.13.0
+    "@babel/helper-function-name": ^7.12.13
+    "@babel/helper-split-export-declaration": ^7.12.13
+    "@babel/parser": ^7.13.0
+    "@babel/types": ^7.13.0
+    debug: ^4.1.0
+    globals: ^11.1.0
+    lodash: ^4.17.19
+  checksum: 7d584b5541396b02f6973ba8ec8a067f2a6c2fd2e894c663dfae36e86e65a004a6865fbffbfc89ca040c894f9c12134bb971d31f09e7ec32c28e9b18bf737f2a
   languageName: node
   linkType: hard
 
@@ -1444,6 +1516,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/types@npm:7.13.0":
+  version: 7.13.0
+  resolution: "@babel/types@npm:7.13.0"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.12.11
+    lodash: ^4.17.19
+    to-fast-properties: ^2.0.0
+  checksum: 3dbb08add345325a49e1deebefa8d3774a8ab055c4be675c339a389358f4b3443652ded4bfdb230b342c6af12593a6fd3fb95156564e7ec84081018815896821
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.0.0, @babel/types@npm:^7.15.6, @babel/types@npm:^7.18.6, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
   version: 7.18.6
   resolution: "@babel/types@npm:7.18.6"
@@ -1451,6 +1534,16 @@ __metadata:
     "@babel/helper-validator-identifier": ^7.18.6
     to-fast-properties: ^2.0.0
   checksum: 9561d9ffba7ab879aca36dfb7a9b632944952d995e99faaabb6e5f14300e01516894b6fd1976cdd3c515fff12120ec708bdcb3fbc4f92ccead274e9c6c1ce031
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.13.0, @babel/types@npm:^7.18.7":
+  version: 7.18.7
+  resolution: "@babel/types@npm:7.18.7"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.18.6
+    to-fast-properties: ^2.0.0
+  checksum: 3114ce161c4ebcb70271e168aa5af5cecedf3278209161d5ba6124bd3f9cb02e3f3ace587ad1b53f7baa153b6b3714720721c72a9ef3ec451663862f9cc1f014
   languageName: node
   linkType: hard
 
@@ -1499,6 +1592,7 @@ __metadata:
     "@nrwl/web": 14.3.6
     "@nrwl/workspace": 14.3.6
     "@testing-library/react": 13.3.0
+    "@trivago/prettier-plugin-sort-imports": ^3.2.0
     "@types/jest": 27.4.1
     "@types/lodash-es": ^4
     "@types/node": 16.11.7
@@ -2329,7 +2423,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/gen-mapping@npm:^0.3.0":
+"@jridgewell/gen-mapping@npm:^0.3.0, @jridgewell/gen-mapping@npm:^0.3.2":
   version: 0.3.2
   resolution: "@jridgewell/gen-mapping@npm:0.3.2"
   dependencies:
@@ -3788,6 +3882,23 @@ __metadata:
   version: 2.0.0
   resolution: "@tootallnate/once@npm:2.0.0"
   checksum: ad87447820dd3f24825d2d947ebc03072b20a42bfc96cbafec16bff8bbda6c1a81fcb0be56d5b21968560c5359a0af4038a68ba150c3e1694fe4c109a063bed8
+  languageName: node
+  linkType: hard
+
+"@trivago/prettier-plugin-sort-imports@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "@trivago/prettier-plugin-sort-imports@npm:3.2.0"
+  dependencies:
+    "@babel/core": 7.13.10
+    "@babel/generator": 7.13.9
+    "@babel/parser": 7.14.6
+    "@babel/traverse": 7.13.0
+    "@babel/types": 7.13.0
+    javascript-natural-sort: 0.7.1
+    lodash: 4.17.21
+  peerDependencies:
+    prettier: 2.x
+  checksum: 22461433fa0dc82621713cdfb88f8f527c6c41729e9859bb7f0106ef23c35b0da591ee7fed63516be7e8df5604dc8055f0c7e200fed1ef97f44000c9fe25a890
   languageName: node
   linkType: hard
 
@@ -9597,6 +9708,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"javascript-natural-sort@npm:0.7.1":
+  version: 0.7.1
+  resolution: "javascript-natural-sort@npm:0.7.1"
+  checksum: 161e2c512cc7884bc055a582c6645d9032cab88497a76123d73cb23bfb03d97a04cf7772ecdb8bd3366fc07192c2f996366f479f725c23ef073fffe03d6a586a
+  languageName: node
+  linkType: hard
+
 "jest-changed-files@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-changed-files@npm:27.5.1"
@@ -14318,6 +14436,13 @@ __metadata:
   version: 0.7.3
   resolution: "source-map@npm:0.7.3"
   checksum: cd24efb3b8fa69b64bf28e3c1b1a500de77e84260c5b7f2b873f88284df17974157cc88d386ee9b6d081f08fdd8242f3fc05c953685a6ad81aad94c7393dedea
+  languageName: node
+  linkType: hard
+
+"source-map@npm:^0.5.0":
+  version: 0.5.7
+  resolution: "source-map@npm:0.5.7"
+  checksum: 5dc2043b93d2f194142c7f38f74a24670cd7a0063acdaf4bf01d2964b402257ae843c2a8fa822ad5b71013b5fcafa55af7421383da919752f22ff488bc553f4d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Fix lint issues and re-format codebase with sort imports plugin

## Changes

- Fix `@nrwl/nx/enforce-module-boundaries` lint issue
- Add `@trivago/prettier-plugin-sort-imports`

## Notes

Currently `import type` is treated same as normal `import`, ideally we want to move `import type` to the top, have to wait till this is merged https://github.com/trivago/prettier-plugin-sort-imports/pull/153
