### PR TITLE
[Fix] Provide a default function call to ensure proposal is enacted correctly

### DIFF
--- a/libs/service/cennznet/src/getSubmitProposalExtrinsic.ts
+++ b/libs/service/cennznet/src/getSubmitProposalExtrinsic.ts
@@ -5,13 +5,17 @@ export const getSubmitProposalExtrinsic = (
 	api: Api,
 	justificationUrl: string,
 	enactmentDelay: number,
-	functionCall: [string, string, ...string[]]
+	functionCall: [string, string, ...string[]] | SubmittableExtrinsic<"promise">
 ): SubmittableExtrinsic<"promise"> => {
-	const [section, method, ...args] = functionCall;
-	const call = api.createType("Call", api.tx[section][method](...args));
+	let extrinsic = functionCall;
+
+	if (Array.isArray(functionCall)) {
+		const [section, method, ...args] = functionCall;
+		extrinsic = api.tx[section][method](...args);
+	}
 
 	return api.tx.governance.submitProposal(
-		call.toHex(),
+		api.createType("Call", extrinsic).toHex(),
 		justificationUrl,
 		enactmentDelay
 	);

--- a/libs/web/hooks/src/useProposalNewForm.ts
+++ b/libs/web/hooks/src/useProposalNewForm.ts
@@ -74,13 +74,15 @@ export const useProposalNewForm = () => {
 				const { pinHash, pinUrl } = await pinProposalData(proposalData);
 
 				// 2. Send governance.submitProposal extrinsinc
+				// note the default `api.tx.system.remark("Proposal enacted")` will not execute
+				// as `system.remark` is not a priveledged command, but good enough to serve as placeholder
 				const extrinsic = getSubmitProposalExtrinsic(
 					api,
 					pinUrl,
 					enactmentDelay,
 					functionCall.length
 						? functionCall
-						: ["system", "remark", `Proposal enacted`]
+						: api.tx.system.remark("Proposal enacted")
 				);
 				await signAndSend([extrinsic, sponsor, { signer: wallet.signer }], {
 					onHashed() {


### PR DESCRIPTION
## Summary

A proposal requires a valid function call to be enacted successfully. This PR adds a generic function call when `functionCall` is undefined