### PR TITLE
[Spike] Adjust element sizings

### DIFF
--- a/apps/gov-website/globals.css
+++ b/apps/gov-website/globals.css
@@ -27,7 +27,7 @@ input::-webkit-input-placeholder {
 }
 
 .markdown code {
-	@apply text-hero border-hero bg-light inline-block rounded border px-[4px] text-sm;
+	@apply text-hero border-hero bg-light inline-block rounded border px-[4px] text-xs;
 }
 
 .markdown pre {

--- a/apps/gov-website/pages/api/identity/judgement.tsx
+++ b/apps/gov-website/pages/api/identity/judgement.tsx
@@ -67,7 +67,7 @@ export default withMethodGuard(
 			]);
 
 			// 4. Assign user with a special role
-			await assignDiscordRole(discordUsername);
+			// await assignDiscordRole(discordUsername);
 
 			return res.json({ ok: true });
 		} catch (error) {

--- a/apps/gov-website/pages/api/identity/judgement.tsx
+++ b/apps/gov-website/pages/api/identity/judgement.tsx
@@ -67,7 +67,7 @@ export default withMethodGuard(
 			]);
 
 			// 4. Assign user with a special role
-			// await assignDiscordRole(discordUsername);
+			await assignDiscordRole(discordUsername);
 
 			return res.json({ ok: true });
 		} catch (error) {

--- a/apps/gov-website/pages/popup/signin.tsx
+++ b/apps/gov-website/pages/popup/signin.tsx
@@ -29,7 +29,7 @@ const SignIn: NextPage = () => {
 	return (
 		<Layout.PageWrapper>
 			<div className="flex flex-1 flex-col items-center justify-center">
-				<div>
+				<div className="prose">
 					Redirecting to {capitalize(provider as BuiltInProviderType)} for
 					authentication...
 				</div>

--- a/apps/gov-website/pages/proposal/new.tsx
+++ b/apps/gov-website/pages/proposal/new.tsx
@@ -54,6 +54,10 @@ const NewProposal: NextPage<NewProposalProps> = ({ extrinsics }) => {
 		setTimeout(resetForm, 200);
 	}, [closeDialog]);
 
+	useEffect(() => {
+		if (formState?.status === "Cancelled") closeDialog();
+	}, [closeDialog, formState]);
+
 	const onDialogClose = useCallback(() => {
 		if (!formState?.status || formState?.status === "Cancelled") return;
 		onDialogDismiss();

--- a/apps/gov-website/pages/proposal/new.tsx
+++ b/apps/gov-website/pages/proposal/new.tsx
@@ -1,5 +1,5 @@
 import type { GetStaticProps, NextPage } from "next";
-import { ChangeEventHandler, useCallback, useState } from "react";
+import { ChangeEventHandler, useCallback, useEffect, useState } from "react";
 
 import {
 	extractCallableExtrinsics,
@@ -69,7 +69,7 @@ const NewProposal: NextPage<NewProposalProps> = ({ extrinsics }) => {
 			<Layout.PageContent>
 				<Layout.PageHeader>Submit a Proposal</Layout.PageHeader>
 
-				<p className="prose mb-8 text-base">
+				<p className="prose mb-[1.5em] text-lg">
 					To submit a proposal you must be a CENNZnet Councillor. Lorem laborum
 					dolor minim mollit eu reprehenderit culpa dolore labore dolor mollit
 					commodo do anim incididunt sunt id pariatur elit tempor nostrud nulla

--- a/apps/gov-website/tailwind.config.js
+++ b/apps/gov-website/tailwind.config.js
@@ -27,6 +27,19 @@ module.exports = {
 				"sharp-7": "7px 7px 0px 0px",
 			},
 		},
+
+		fluidType: {
+			settings: {
+				fontSizeMin: 0.875, // 1.125rem === 18px
+				fontSizeMax: 1, // 1.25rem === 20px
+				ratioMin: 1, // Multiplicator Min
+				ratioMax: 1.2, // Multiplicator Max
+				screenMin: 20, // 20rem === 320px
+				screenMax: 96, // 96rem === 1536px
+				unit: "rem", // default is rem but it's also possible to use 'px'
+				prefix: "", // set a prefix to use it alongside the default font sizes
+			},
+		},
 	},
 	plugins: [
 		require("@tailwindcss/typography"),

--- a/apps/gov-website/tailwind.config.js
+++ b/apps/gov-website/tailwind.config.js
@@ -30,8 +30,8 @@ module.exports = {
 
 		fluidType: {
 			settings: {
-				fontSizeMin: 0.875, // 1.125rem === 18px
-				fontSizeMax: 1, // 1.25rem === 20px
+				fontSizeMin: 0.875, // 0.875rem === 14px
+				fontSizeMax: 1, // 1rem === 16px
 				ratioMin: 1, // Multiplicator Min
 				ratioMax: 1.2, // Multiplicator Max
 				screenMin: 20, // 20rem === 320px

--- a/libs/web/components/src/AccountSelect.tsx
+++ b/libs/web/components/src/AccountSelect.tsx
@@ -21,7 +21,7 @@ export const AccountSelect = forwardRef<HTMLSelectElement, SelectProps>(
 			<Select
 				ref={ref}
 				placeholder="Connect CENNZnet Wallet"
-				inputClassName="!py-3"
+				inputClassName="!py-[0.875rem]"
 				defaultValue={selectedAccount}
 				onChange={onAccountSelect}
 				endAdornment={

--- a/libs/web/components/src/IdentityForm.tsx
+++ b/libs/web/components/src/IdentityForm.tsx
@@ -19,16 +19,16 @@ export const IdentityForm: FC<
 		<form {...props}>
 			<Layout.PageHeader>Set your identity</Layout.PageHeader>
 
-			<p className="prose mb-8 text-base">
+			<p className="prose mb-[1.5em] text-lg">
 				The Identity Module ensures an authentic governance and voting
 				experience. It does this by requiring every voting wallet to be
 				connected to 2 social accounts.
 			</p>
 
-			<h2 className="font-display border-hero mb-4 border-b-2 text-2xl uppercase">
+			<h2 className="font-display border-hero mb-4 border-b-2 text-4xl uppercase">
 				Connect your wallet
 			</h2>
-			<p className="prose mb-8">
+			<p className="prose mb-[1em] text-base">
 				Connect your voting wallet here. This is the wallet that will be checked
 				against the staking requirement. If you have a controller wallet with a
 				stash account that is actively staking, you may connect your controller
@@ -40,10 +40,10 @@ export const IdentityForm: FC<
 				<IdentityFieldSet.Account />
 			</fieldset>
 
-			<h2 className="font-display border-hero mb-4 border-b-2 text-2xl uppercase">
+			<h2 className="font-display border-hero mb-4 border-b-2 text-4xl uppercase">
 				Connect your social channels
 			</h2>
-			<p className="prose mb-8">
+			<p className="prose mb-[1em] text-base">
 				If your wallet is yet to be associated with a social account, you will
 				be able to sign in to Twitter and Discord below. This will establish
 				that you are the owner of the social accounts and therefore a real

--- a/libs/web/components/src/IdentityFormDialog.tsx
+++ b/libs/web/components/src/IdentityFormDialog.tsx
@@ -28,7 +28,7 @@ export const IdentityFormDialog: FC<IdentityFormDialogProps> = ({
 			>
 				<Choose>
 					<Choose.When condition={formState?.status === "Ok"}>
-						<p className="prose text-center">
+						<p className="prose text-center  text-sm">
 							Your identity has been successfully set. Visit Discord to view the
 							Governance channels with your new role!
 						</p>
@@ -54,7 +54,7 @@ export const IdentityFormDialog: FC<IdentityFormDialogProps> = ({
 					</Choose.When>
 
 					<Choose.When condition={formState?.status === "NotOk"}>
-						<p className="prose text-center">
+						<p className="prose text-center text-sm">
 							Something went wrong while processing your request.
 						</p>
 
@@ -72,7 +72,7 @@ export const IdentityFormDialog: FC<IdentityFormDialogProps> = ({
 					</Choose.When>
 
 					<Choose.When condition={formState?.step === "Await"}>
-						<p className="prose text-center">
+						<p className="prose text-center text-sm">
 							Please sign the transaction when prompted...
 						</p>
 					</Choose.When>
@@ -82,7 +82,7 @@ export const IdentityFormDialog: FC<IdentityFormDialogProps> = ({
 							formState?.step !== "Idle" && formState?.status !== "NotOk"
 						}
 					>
-						<p className="prose text-center">
+						<p className="prose text-center text-sm">
 							Please wait until this process completes...
 						</p>
 					</Choose.When>

--- a/libs/web/components/src/Layout.tsx
+++ b/libs/web/components/src/Layout.tsx
@@ -33,7 +33,7 @@ const PageContent: FC<PropsWithChildren> = ({ children }) => (
 );
 
 const PageHeader: FC<PropsWithChildren> = ({ children }) => (
-	<h1 className="font-display text-hero mb-[0.4em] text-center text-6xl uppercase">
+	<h1 className="font-display text-hero mb-[0.4em] text-center text-8xl uppercase">
 		{children}
 	</h1>
 );

--- a/libs/web/components/src/MarkdownField.tsx
+++ b/libs/web/components/src/MarkdownField.tsx
@@ -31,7 +31,7 @@ export const MarkdownField = forwardRef<
 				"border-hero flex min-h-[400px] w-full  flex-col border-2 bg-white"
 			)}
 		>
-			<div className="flex border-b border-b-slate-200 bg-white p-2 text-slate-600">
+			<div className="flex border-b border-b-slate-200 bg-white p-2 text-xs text-slate-600">
 				<span
 					onClick={onWriteClick}
 					className={classNames(
@@ -60,7 +60,7 @@ export const MarkdownField = forwardRef<
 					value={value}
 					rows={rows}
 					maxLength={1024}
-					className="absolute inset-0 resize-none p-2 font-mono text-sm outline-none"
+					className="absolute inset-0 resize-none p-2 font-mono text-xs outline-none"
 				/>
 
 				<div
@@ -75,8 +75,8 @@ export const MarkdownField = forwardRef<
 					</Markdown>
 				</div>
 			</div>
-			<span className="flex bg-slate-100 p-2 text-xs">
-				<p className="markdown flex-1">
+			<span className="flex bg-slate-100 p-2">
+				<p className="markdown flex-1 text-xs">
 					Supported markdown: <strong>**bold**</strong>, <em>*italic*</em>,{" "}
 					<a href="#">[link]()</a>, <code className="!text-xs">`code`</code> and{" "}
 					<span className="mb-4 inline whitespace-pre-wrap bg-slate-50">
@@ -85,7 +85,12 @@ export const MarkdownField = forwardRef<
 						</code>
 					</span>
 				</p>
-				<p className={classNames(characterCount === 1024 && "text-red-600")}>
+				<p
+					className={classNames(
+						characterCount === 1024 && "text-red-600",
+						"text-xs"
+					)}
+				>
 					{characterCount} / 1024
 				</p>
 			</span>

--- a/libs/web/components/src/ProposalNewForm.tsx
+++ b/libs/web/components/src/ProposalNewForm.tsx
@@ -28,7 +28,7 @@ export const ProposalNewForm: FC<
 
 	return (
 		<form {...props}>
-			<h2 className="font-display border-hero mb-4 border-b-2 text-2xl uppercase">
+			<h2 className="font-display border-hero mb-4 border-b-2 text-4xl uppercase">
 				Proposal Details
 			</h2>
 
@@ -85,7 +85,7 @@ export const ProposalNewForm: FC<
 			</fieldset>
 
 			<If condition={callToggle.checked}>
-				<h2 className="font-display border-hero mb-4 border-b-2 text-2xl uppercase">
+				<h2 className="font-display border-hero mb-4 border-b-2 text-4xl uppercase">
 					Function Call
 				</h2>
 
@@ -110,7 +110,7 @@ export const ProposalNewForm: FC<
 			</h2>
 
 			<fieldset className="mb-6">
-				<p className="prose mb-4">
+				<p className="prose mb-[1em] text-base">
 					Ex consequat occaecat id nulla voluptate anim eu velit et laboris
 					reprehenderit ut dolor magna ut minim voluptate labore non adipisicing
 				</p>

--- a/libs/web/components/src/ProposalNewFormDialog.tsx
+++ b/libs/web/components/src/ProposalNewFormDialog.tsx
@@ -3,12 +3,7 @@ import { Choose, If } from "react-extras";
 
 import { StepProgress } from "@app-gov/web/components";
 import { ProposalNewFormState } from "@app-gov/web/hooks";
-import {
-	CheckCircle,
-	DiscordLogo,
-	ExclamationCircle,
-	Spinner,
-} from "@app-gov/web/vectors";
+import { DiscordLogo } from "@app-gov/web/vectors";
 
 import { Button, TransactionDialog, TransactionDialogProps } from "./";
 
@@ -33,7 +28,7 @@ export const ProposalNewFormDialog: FC<ProposalNewFormDialogProps> = ({
 			>
 				<Choose>
 					<Choose.When condition={formState?.status === "Ok"}>
-						<p className="text-center">
+						<p className="prose text-center  text-sm">
 							Your proposal has been submitted successfully, [and maybe some
 							message to view the proposal on Discord].
 						</p>
@@ -53,7 +48,7 @@ export const ProposalNewFormDialog: FC<ProposalNewFormDialogProps> = ({
 					</Choose.When>
 
 					<Choose.When condition={formState?.status === "NotOk"}>
-						<p className="text-center">
+						<p className="prose text-center text-sm">
 							Something went wrong while processing your request.
 						</p>
 
@@ -71,7 +66,7 @@ export const ProposalNewFormDialog: FC<ProposalNewFormDialogProps> = ({
 					</Choose.When>
 
 					<Choose.When condition={formState?.step === "Await"}>
-						<p className="text-center">
+						<p className="prose text-center text-sm">
 							Please sign the transaction when prompted...
 						</p>
 					</Choose.When>
@@ -81,7 +76,7 @@ export const ProposalNewFormDialog: FC<ProposalNewFormDialogProps> = ({
 							formState?.step === "Submit" || formState?.step === "Process"
 						}
 					>
-						<p className="text-center">
+						<p className="prose text-center text-sm">
 							Please wait until this proccess completes...
 						</p>
 					</Choose.When>

--- a/libs/web/components/src/StepProgress.tsx
+++ b/libs/web/components/src/StepProgress.tsx
@@ -28,7 +28,7 @@ export const StepProgress: FC<StepProgressProps> = ({
 						<Choose.When condition={index < stepIndex}>
 							<div>
 								<IconWrapper>
-									<CheckCircleFilled className="text-hero h-10 w-10 sm:h-12 sm:w-12" />
+									<CheckCircleFilled className="text-hero h-8 w-8 lg:h-10 lg:w-10" />
 									<StepLine active />
 								</IconWrapper>
 
@@ -41,25 +41,25 @@ export const StepProgress: FC<StepProgressProps> = ({
 								<IconWrapper>
 									<If condition={index === steps.length - 1}>
 										<If condition={!error}>
-											<CheckCircleFilled className="text-hero h-12 w-12" />
+											<CheckCircleFilled className="text-hero h-8 w-8 lg:h-10 lg:w-10" />
 										</If>
 
 										<If condition={!!error}>
 											<IconWrapper>
-												<ExclamationCircle className="text-hero h-12 w-12" />
+												<ExclamationCircle className="text-hero h-6 w-6 lg:h-8 lg:w-8" />
 											</IconWrapper>
 										</If>
 									</If>
 
 									<If condition={index < steps.length - 1}>
 										<If condition={!error}>
-											<Spinner className="text-hero mx-1 h-10 w-10 animate-spin" />
+											<Spinner className="text-hero mx-1 h-6 w-6 animate-spin lg:h-8 lg:w-8" />
 											<StepLine active />
 										</If>
 
 										<If condition={!!error}>
 											<IconWrapper>
-												<ExclamationCircle className="text-hero h-12 w-12" />
+												<ExclamationCircle className="text-hero h-6 w-6 lg:h-8 lg:w-8" />
 												<StepLine />
 											</IconWrapper>
 										</If>
@@ -75,7 +75,7 @@ export const StepProgress: FC<StepProgressProps> = ({
 								<IconWrapper>
 									<div
 										className={classNames(
-											"mx-1 h-10 w-10 rounded-3xl border-4",
+											"mx-1 h-6 w-6 rounded-3xl border-2 lg:h-8 lg:w-8",
 											error
 												? "border-hero/40"
 												: index === stepIndex + 1
@@ -118,7 +118,7 @@ const StepText: FC<StepTextProps> = ({ waiting, children }) => (
 const StepLine: FC<{ active?: boolean }> = ({ active }) => (
 	<span
 		className={classNames(
-			"h-0 w-16 rounded-xl border-2 md:w-24 lg:w-32",
+			"h-0 w-16 rounded-xl border lg:w-20",
 			active ? "border-hero" : "border-hero/40"
 		)}
 	/>


### PR DESCRIPTION
## Summary

Everything feels rather big atm, and I like to have the `fluidType` is 16px-based instead of 18px

## Changes

- Adjust the settings of `tailwindcss-fluid-type` plugin
- Update text sizing, margin sizing for all elements
- Add a sneaky fix to close the dialog when clicking "Cancel" on the Wallet prompt