### PR TITLE
[Hotfix] Avoid button text being the same colour as background when active

### DIFF
--- a/libs/web/components/src/Button.tsx
+++ b/libs/web/components/src/Button.tsx
@@ -39,7 +39,7 @@ export const Button: FC<IntrinsicElements["button"] & ButtonProps> = ({
 				}[size],
 
 				active &&
-					`bg-[#F5ECFF] text-hero pointer-events-none translate-y-0 translate-x-0 shadow-none`
+					`!bg-light !text-hero pointer-events-none translate-y-0 translate-x-0 shadow-none`
 			)}
 			{...props}
 		>

--- a/libs/web/components/src/Button.tsx
+++ b/libs/web/components/src/Button.tsx
@@ -30,7 +30,7 @@ export const Button: FC<IntrinsicElements["button"] & ButtonProps> = ({
 					hero: "bg-hero border-hero shadow-sharp shadow-dark hover:text-hero translate-y-[-3px] translate-x-[-3px] border-2 uppercase text-white hover:bg-white active:translate-y-0 active:translate-x-0 active:shadow-none",
 
 					white:
-						" shadow-sharp shadow-dark text-hero hover:border-hero translate-y-[-3px] translate-x-[-3px] border-2 border-white bg-white uppercase hover:bg-white active:translate-y-0 active:translate-x-0 active:shadow-none ",
+						"shadow-sharp shadow-dark text-hero hover:border-hero translate-y-[-3px] translate-x-[-3px] border-2 border-white bg-white uppercase hover:bg-white active:translate-y-0 active:translate-x-0 active:shadow-none ",
 				}[variant],
 
 				{
@@ -39,7 +39,7 @@ export const Button: FC<IntrinsicElements["button"] & ButtonProps> = ({
 				}[size],
 
 				active &&
-					`bg-light !text-hero  pointer-events-none translate-y-0 translate-x-0 shadow-none`
+					`bg-light pointer-events-none translate-y-0 translate-x-0 shadow-none`
 			)}
 			{...props}
 		>

--- a/libs/web/components/src/Button.tsx
+++ b/libs/web/components/src/Button.tsx
@@ -39,7 +39,7 @@ export const Button: FC<IntrinsicElements["button"] & ButtonProps> = ({
 				}[size],
 
 				active &&
-					`bg-light pointer-events-none translate-y-0 translate-x-0 shadow-none`
+					`bg-[#F5ECFF] text-hero pointer-events-none translate-y-0 translate-x-0 shadow-none`
 			)}
 			{...props}
 		>


### PR DESCRIPTION
## Summary
 - `bg-light` appears to be broken - made it important

<img width="729" alt="Screen Shot 2022-07-13 at 2 00 55 PM" src="https://user-images.githubusercontent.com/52016903/178634972-c5ae12e4-2e24-4bcd-8b9e-59d9f025e5ab.png">