### PR TITLE
[Spike] Update Discord DM & error messages

### DIFF
--- a/apps/gov-website/pages/api/identity/judgement.tsx
+++ b/apps/gov-website/pages/api/identity/judgement.tsx
@@ -107,9 +107,9 @@ const assignDiscordRole = async (discordUsername: string) => {
 	await user.roles.add(identityRole);
 	// Send a message to the user letting them know the verification has been successful
 	await user.send(
-		`***Congratulations on completing the steps for verifying your identity.*** \n\n` +
-			`Thank you for supporting CENNZnet and helping to build the blockchain for the Metaverse!\n` +
-			`You have been assigned the ${identityRole.name} role and can now participate in private channels\n` +
+		`***Welcome Citizen ${username}.*** \n\n` +
+			`Thank you for doing your part in governing the CENNZnet blockchain!\n` +
+			`You have been assigned the ${identityRole.name} role and can now participate in private channels.\n` +
 			`Please note that for your safety, we will never ask for private keys, seed phrases or send links via DM.`
 	);
 };

--- a/libs/web/hooks/src/useIdentityConnectForm.ts
+++ b/libs/web/hooks/src/useIdentityConnectForm.ts
@@ -101,7 +101,7 @@ export const useIdentityConnectForm = () => {
 
 				setFormStatus(
 					"NotOk",
-					`[${error?.code ?? "UNKNOWN"}] ${error?.message}`
+					`[${error?.code ?? "UNKNOWN"}] ${error?.details ?? error.message}`
 				);
 			}
 		},

--- a/libs/web/hooks/src/useIdentityConnectForm.ts
+++ b/libs/web/hooks/src/useIdentityConnectForm.ts
@@ -77,12 +77,16 @@ export const useIdentityConnectForm = () => {
 				});
 
 				if (!response.ok) {
-					const responseText = JSON.parse(await response.text());
+					let responseBody;
+					const contentType = response.headers.get("Content-Type");
+
+					if (contentType?.includes("application/json"))
+						responseBody = await response.json();
 
 					throw {
 						code: `APP/${response.status}`,
 						message: response.statusText,
-						details: responseText?.message ?? responseText?.details,
+						details: responseBody?.message ?? responseBody?.details,
 					};
 				}
 

--- a/libs/web/hooks/src/useIdentityConnectForm.ts
+++ b/libs/web/hooks/src/useIdentityConnectForm.ts
@@ -77,10 +77,12 @@ export const useIdentityConnectForm = () => {
 				});
 
 				if (!response.ok) {
+					const responseText = JSON.parse(await response.text());
+
 					throw {
 						code: `APP/${response.status}`,
 						message: response.statusText,
-						details: JSON.parse(await response.text()).message,
+						details: responseText?.message ?? responseText?.details,
 					};
 				}
 


### PR DESCRIPTION
## Summary

 - Update Discord `role assigned` DM
 - Use `responseText?.message ?? responseText?.details` as Discord likes to put its message in `details`
 - Closes #51

## Notes
 - If there is a gateway timeout, res.json() fails resulting in a poor error message, I plan to tackle this later along with #48

## Screenshot

<img width="1430" alt="Screen Shot 2022-07-14 at 3 47 17 PM" src="https://user-images.githubusercontent.com/52016903/178894441-6b6b0e62-6987-4a34-8250-813543cdbe1d.png">
