### PR TITLE
Remove the `npm-run-all` as dependency for runtime

### DIFF
--- a/apps/gov-relayer/package.json
+++ b/apps/gov-relayer/package.json
@@ -2,8 +2,7 @@
   "license": "MIT",
   "scripts": {
     "relayer:proposal-pub": "node ./main.js proposal-pub",
-    "relayer:proposal-sub": "node ./main.js proposal-sub",
-    "relayer": "run-p relayer:proposal-pub relayer:proposal-sub relayer:proposal-sub"
+    "relayer:proposal-sub": "node ./main.js proposal-sub"
   },
   "dependencies": {
     "@cennznet/api": "^2.1.1-alpha.4",
@@ -11,7 +10,6 @@
     "chalk": "^4",
     "dotenv": "^16.0.1",
     "mongoose": "^6.4.4",
-    "npm-run-all": "^4.1.5",
     "tslib": "^2.3.0",
     "winston": "^3.8.1",
     "yargs": "^17.5.1"


### PR DESCRIPTION
## Summary

Remove the `npm-run-all` as dependency for for runtime as DevOps doesn't use it to run the processes

cc @juehai 