### PR TITLE
[Hotfix] Avoid property `justificationUri` is undefined error

### DIFF
--- a/apps/gov-website/pages/proposal/[pid].tsx
+++ b/apps/gov-website/pages/proposal/[pid].tsx
@@ -57,8 +57,13 @@ export const getStaticProps: GetStaticProps = async (context) => {
 		.findOne({ proposalId: pid })
 		.lean();
 
+	if (!proposal?.justificationUri)
+		return {
+			notFound: true,
+		};
+
 	const justification = await resolveProposalJustification(
-		proposal?.justificationUri ?? ""
+		proposal.justificationUri
 	);
 
 	const vetoThreshold = await fetchProposalVetoThreshold(api);

--- a/apps/gov-website/pages/proposal/[pid].tsx
+++ b/apps/gov-website/pages/proposal/[pid].tsx
@@ -58,7 +58,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
 		.lean();
 
 	const justification = await resolveProposalJustification(
-		proposal.justificationUri
+		proposal?.justificationUri ?? ""
 	);
 
 	const vetoThreshold = await fetchProposalVetoThreshold(api);


### PR DESCRIPTION
## Summary

 - Closes #76

Proposal #68 was `ApprovedEnacted` so had been cleared from storage on CENNZnet, this fix avoids that error but means `proposal/68` will now 404.

Alternatively we can store the justification & proposal call in full in MongoDB


