### PR TITLE
[Fix] Relayer performance issue

### DIFF
--- a/apps/gov-relayer/commands/proposal-sub.ts
+++ b/apps/gov-relayer/commands/proposal-sub.ts
@@ -77,12 +77,19 @@ module.exports = {
 					}
 				} catch (error) {
 					logger.error("%s", error);
-					const result = await requeueMessage(
-						proposalQueue,
-						message,
-						MESSAGE_MAX_RETRY
-					);
-					logger.info(`Proposal #%d: ${result}`, body.proposalId);
+					const { type } = message.properties;
+					if (type === "proposal-new") {
+						const result = await requeueMessage(
+							proposalQueue,
+							message,
+							MESSAGE_MAX_RETRY
+						);
+						logger.info(`Proposal #%d: ${result}`, body.proposalId);
+					}
+
+					if (type === "proposal-activity") {
+						logger.info(`Proposal #%d: ❌ skipped`, body.proposalId);
+					}
 				}
 				await message.ack();
 			};

--- a/libs/service/relayer/src/handleNewProposalMessage.ts
+++ b/libs/service/relayer/src/handleNewProposalMessage.ts
@@ -31,6 +31,11 @@ export const handleNewProposalMessage = async (
 		{ proposalId }
 	);
 	const handleMessage = async () => {
+		// Create a record in the `proposals` collection to ack that it has been processed
+		await updateProposalRecord({
+			proposalId,
+		});
+
 		logger.info("Proposal #%d: 🎾 fetch info [1/2]", proposalId);
 		const proposalInfo = await fetchProposalInfo(api, proposalId);
 		if (!proposalInfo) return;

--- a/libs/service/relayer/src/handleProposalActivityMessage.ts
+++ b/libs/service/relayer/src/handleProposalActivityMessage.ts
@@ -90,7 +90,7 @@ export const handleProposalActivityMessage = async (
 		}
 
 		if (!Object.keys(updatedData).length) return;
-		logger.info("Proposal #%d: 💬  update Discord [2/3]", proposalId);
+		logger.info("Proposal #%d: 💬 update Discord [2/3]", proposalId);
 
 		const proposalJustification = await resolveProposalJustification(
 			proposal.justificationUri ?? ""


### PR DESCRIPTION
## Summary

Make couple of tweaks to make sure relayer doesn't get stuck on processing skippable proposals

## Changes

- Avoid re-queue messages for `proposal-activity` type
- Avoid process new proposal that didn't return `proposalInfo` earlier
- Remove extra spacing in console message for update Discord