### PR TITLE
Add extra guard to ignore proposals that doesn't have `status`

### DIFF
--- a/apps/gov-website/pages/proposal/[pid].tsx
+++ b/apps/gov-website/pages/proposal/[pid].tsx
@@ -35,7 +35,7 @@ export const getStaticPaths = async () => {
 	const mdb = await getMongoClient(MONGODB_URI);
 	const proposals = await mdb
 		.model<ProposalModel>("Proposal")
-		.find()
+		.find({ status: { $ne: null } })
 		.sort("-proposalId");
 
 	return {


### PR DESCRIPTION
## Summary

`getStaticPaths` currently get all proposals regardless how much of data is available

## Changes

- Set to only find proposals that have `status`