### PR TITLE
[Fix] API `autoConnect`

### DIFF
--- a/libs/service/cennznet/src/waitForBlock.ts
+++ b/libs/service/cennznet/src/waitForBlock.ts
@@ -7,13 +7,13 @@ export async function waitForBlock(
 ): Promise<void> {
 	let firstBlock: number;
 	let unsubscribeFn: () => void;
-	return new Promise((resolve) => {
+	return new Promise((resolve, reject) => {
 		api.derive.chain
 			.subscribeNewHeads((header) => {
 				const headerBlock = header.number.toNumber();
 				if (!firstBlock) firstBlock = header.number.toNumber();
 				if (headerBlock < firstBlock + numberOfBlocks) return;
-				
+
 				callback?.(headerBlock);
 				unsubscribeFn?.();
 				resolve();
@@ -21,5 +21,10 @@ export async function waitForBlock(
 			.then((unsubscribe) => {
 				unsubscribeFn = unsubscribe;
 			});
+
+		setInterval(() => {
+			if (api.isConnected) return;
+			reject(new Error("‼️  API is disconnected"));
+		}, 1000);
 	});
 }


### PR DESCRIPTION
## Summary

Polkadot `WsProvider` has an `autoConnectMs` parameter which is default to `2500ms`, but looks like even after reconnect, our `api.derive.chain.subscribeNewHeads` doesn't resume.

## Changes

- Add a regular check to make sure `api` is connected, if not throw error

## Notes

- Closes #82 