### PR TITLE
Add a `proposal-patch <start> <end>` command to patch up DB

### DIFF
--- a/apps/gov-relayer/commands/proposal-patch.ts
+++ b/apps/gov-relayer/commands/proposal-patch.ts
@@ -1,0 +1,63 @@
+import { AMQPError } from "@cloudamqp/amqp-client";
+import chalk from "chalk";
+
+import {
+	CENNZ_NETWORK,
+	MONGODB_URI,
+	PROPOSAL_QUEUE,
+	RABBITMQ_URI,
+} from "@app-gov/service/env-vars";
+import { getMongoClient, ProposalModel } from "@app-gov/service/mongodb";
+import { getQueueByName, getRabbitClient } from "@app-gov/service/rabbitmq";
+import { getLogger } from "@app-gov/service/relayer";
+
+module.exports = {
+	command: "proposal-patch <start> <end>",
+	desc: "Start a one-off [ProposalPatch] script to fill in missing proposals",
+	async handler(args) {
+		const logger = getLogger("ProposalPatch");
+		logger.info(
+			`Start process on ${chalk.magenta("%s")}...`,
+			CENNZ_NETWORK.ChainName
+		);
+
+		try {
+			const [amqClient, mdbClient] = await Promise.all([
+				getRabbitClient(RABBITMQ_URI),
+				getMongoClient(MONGODB_URI),
+			]);
+
+			const proposalQueue = await getQueueByName(
+				amqClient,
+				"Producer",
+				PROPOSAL_QUEUE
+			);
+
+			const { start, end } = args;
+			for (let i = start; i <= end; i++) {
+				const proposalId = i;
+				const proposal = await mdbClient
+					.model<ProposalModel>("Proposal")
+					.findOne({ proposalId });
+				//
+				if (proposal?.status) {
+					logger.info(
+						"Proposal #%d: 🔴 ignored, status `%s`",
+						proposalId,
+						proposal.status
+					);
+					continue;
+				}
+				await proposalQueue.publish(JSON.stringify({ proposalId }), {
+					type: "proposal-new",
+				});
+				logger.info("Proposal #%d: 🟢 added", proposalId);
+			}
+			process.exit(0);
+		} catch (error) {
+			if (error instanceof AMQPError) error?.connection?.close();
+			logger.error("%s", error);
+			process.exit(1);
+		}
+	},
+};

--- a/apps/gov-relayer/commands/proposal-patch.ts
+++ b/apps/gov-relayer/commands/proposal-patch.ts
@@ -39,7 +39,6 @@ module.exports = {
 				const proposal = await mdbClient
 					.model<ProposalModel>("Proposal")
 					.findOne({ proposalId });
-				//
 				if (proposal?.status) {
 					logger.info(
 						"Proposal #%d: 🔴 ignored, status `%s`",

--- a/apps/gov-relayer/main.ts
+++ b/apps/gov-relayer/main.ts
@@ -4,4 +4,5 @@ require("yargs")
 	.scriptName("gov-relayer")
 	.command(require("./commands/proposal-pub"))
 	.command(require("./commands/proposal-sub"))
+	.command(require("./commands/proposal-patch"))
 	.help().argv;

--- a/libs/service/relayer/src/getLogger.ts
+++ b/libs/service/relayer/src/getLogger.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import { createLogger, format, Logger, transports } from "winston";
 
-type LoggerService = "ProposalPub" | "ProposalSub";
+type LoggerService = "ProposalPub" | "ProposalSub" | "ProposalPatch";
 
 const instances = {} as Record<LoggerService, Logger>;
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "nx test",
     "relayer:proposal-pub": "node dist/apps/gov-relayer/main.js proposal-pub",
     "relayer:proposal-sub": "node dist/apps/gov-relayer/main.js proposal-sub",
+    "relayer:proposal-patch": "node dist/apps/gov-relayer/main.js proposal-patch",
     "relayer:run": "run-p relayer:proposal-pub relayer:proposal-sub relayer:proposal-sub"
   },
   "private": true,


### PR DESCRIPTION
## Summary

There are quite a few proposals on Rata DB (i.e. `86`) that were not being fetched properly and have been ignored from updating due to how `monitorProposalActivity` only picks up proposals that have a valid `status`.

This PR adds a new command `proposal-patch <start> <end>` that is meant to run on a local machine but connects to the affected DB to add all un-fetched proposals.

To execute, run `yarn relayer:proposal-patch 0 90`